### PR TITLE
Fixing a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ foo@bar:~$/home/my_application_folder cd application
 
 ```
 application/
-└── manager.py
+└── manage.py
 ```
 ```console
 foo@bar:~$/home/my_application_folder/application/ virtualenv --python=python3.7 venv


### PR DESCRIPTION
Fixing a simple typo (manager.py -> manage.py)